### PR TITLE
Use ldap_bind_dn instead of ldap_basedn where required

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This role requires the following variables to be defined elsewhere in the playbo
 ```yaml
 ldap_basedn:       dc=mydomain,dc=net         # Base DN
 ldap_server_uri:   ldap://localhost:389       # LDAP server URI
+ldap_bind_dn:      cn=admin,{{ldap_basedn}}   # Requires ldap_basedn
 ldap_bind_pw:      secret                     # bind password
 ```
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,9 +7,9 @@
     name: slapd
     state: started
 
-- name: Register encripted password
+- name: Register encrypted password
   command: slappasswd -s "{{ldap_bind_pw}}"
-  register: ldap_encripted_password
+  register: ldap_encrypted_password
 
 - name: Copy db templates
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: Load ldap root entry
   ldap_entry:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "{{ldap_basedn}}"
     objectClass:
@@ -42,7 +42,7 @@
 - name: Load groups and users parent entry
   ldap_entry:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "ou={{item}},{{ldap_basedn}}"
     objectClass:
@@ -55,7 +55,7 @@
 - name: Load users
   ldap_entry:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "cn={{item.value.cn}},ou=people,{{ldap_basedn}}"
     objectClass:
@@ -76,7 +76,7 @@
 - name: Load groups
   ldap_entry:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "cn={{item.name}},ou=groups,{{ldap_basedn}}"
     objectClass:
@@ -89,7 +89,7 @@
 - name: Add users to groups
   ldap_attr:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "cn={{item.0.name}},ou=groups,{{ldap_basedn}}"
     name: uniqueMember
@@ -102,7 +102,7 @@
 - name: Remove dummy entry
   ldap_attr:
     server_uri: "{{ldap_server_uri}}"
-    bind_dn: "{{ldap_basedn}}"
+    bind_dn: "{{ldap_bind_dn}}"
     bind_pw: "{{ldap_bind_pw}}"
     dn: "cn={{item.name}},ou=groups,{{ldap_basedn}}"
     name: uniqueMember

--- a/templates/db.ldif
+++ b/templates/db.ldif
@@ -6,7 +6,7 @@ olcSuffix: {{ldap_basedn}}
 dn: olcDatabase={{dbtype}},cn=config
 changetype: modify
 replace: olcRootDN
-olcRootDN: {{ldap_basedn}}
+olcRootDN: {{ldap_bind_dn}}
 
 dn: olcDatabase={{dbtype}},cn=config
 changetype: modify

--- a/templates/db.ldif
+++ b/templates/db.ldif
@@ -11,4 +11,4 @@ olcRootDN: {{ldap_basedn}}
 dn: olcDatabase={{dbtype}},cn=config
 changetype: modify
 replace: olcRootPW
-olcRootPW: {{ldap_encripted_password.stdout}}
+olcRootPW: {{ldap_encrypted_password.stdout}}


### PR DESCRIPTION
Use `ldap_bind_dn` instead of `ldap_basedn` where required.
Fixes errors introduced in #1 