### PR TITLE
Use uid as the RDN of user objects (fixes #7)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,7 @@
     server_uri: "{{ldap_server_uri}}"
     bind_dn: "{{ldap_basedn}}"
     bind_pw: "{{ldap_bind_pw}}"
-    dn: "cn={{item.value.cn}},ou=people,{{ldap_basedn}}"
+    dn: "uid={{item.key}},ou=people,{{ldap_basedn}}"
     objectClass:
       - person
       - organizationalPerson


### PR DESCRIPTION
This will make group membership work as expected because it used an inexistent DN in the membership attribute.